### PR TITLE
Wip/release0.2.3 (#55)

### DIFF
--- a/.contxt.yml
+++ b/.contxt.yml
@@ -174,7 +174,7 @@ task:
       - echo '<div class="report">' >> ./docs/coverage.html
       - go tool cover -func ./docs/test/coverage/test.{{ $test.modul }}.out >> ./docs/coverage.html
       - echo '</div>' >> ./docs/coverage.html
-      - echo '<a target="coverage_details" href="test/coverage/{{ $test.modul }}.html">report for module/{{ $test.modul }}</a>' >> ./docs/coverage.html
+      - echo '<a target="coverage_details" href="test/coverage/{{ $test.modul }}.html">report for {{ $test.modul }}</a>' >> ./docs/coverage.html
     {{- end }}
       - echo "${coverage-template-bottom}" >> ./docs/coverage.html
 


### PR DESCRIPTION
* fix go build

* remove douple task

* extract await as module, fix onerror trigger

* add coverage report creation

* update depandabot depending modules

* add auto-browser-open for coverage report on linux

* more tests for trigger modul

* false in return for aborted exit

* code cleanup

* code cleanup 2

* remove taskrunner

* remove experimental

* remove coverage reports from repo

* ignore coverage reports

* ignore coverage reports (2)