### PR TITLE
add json export cheat. rework of external modules

### DIFF
--- a/.contxt.yml
+++ b/.contxt.yml
@@ -15,7 +15,9 @@ config:
     - ./imports/dependabot.tpl depandabot
     - ./imports/coverage.html coverage
     - ./imports/Makefile.tpl makefile
+    - ./imports/vscode.workspace.yml vscode-ws
   variables:
+      include-dev-externals: ""
       configmodul: github.com/swaros/contxt/module/configure
       coverage-report: ""
       depbot-file: .github/dependabot.yml
@@ -86,6 +88,55 @@ task:
 {{- end }}
 {{- range $k, $modul := $.module }}
 
+  ### create tasks for external modules
+  {{- if not $modul.local}}
+  - id: verify-modul-{{ $modul.modul }}
+    options:
+      invisible: true
+    require:
+      variables:
+        include-dev-externals: "=YES"
+    script:
+      - echo "EXTERNAL >>> verify external module {{ $modul.modul }} on {{ $modul.path }}"
+
+  - id: verify-modul-{{ $modul.modul }}
+    options:
+      invisible: true
+    require:
+      variables:
+        include-dev-externals: "!YES"
+    script:
+      - echo "IGNORE EXTERNAL >>> {{ $modul.modul }}"
+      - echo "to force external modules set var include-dev-externals to yes (ctx run modules-verify -v include-dev-externals=YES) "
+
+  ### add external module
+  - id: verify-modul-{{ $modul.modul }}
+    options:
+      invisible: true
+      ignoreCmdError: true
+    require:
+      system: linux
+      variables:
+        include-dev-externals: "=YES"
+      exists:
+        - {{ $modul.path }}
+    script:
+      - grep {{ $modul.path }} go.work
+    listener:
+      - trigger:
+          onerror: true
+        action:
+          script:
+            - echo "EXTERNAL >>> update go.work for external module {{ $modul.modul }}"
+            - echo "EXTERNAL >>> using path {{ $modul.path }}"
+            - echo "             [go work use {{ $modul.path }}]"
+            - go work use {{ $modul.path }}
+
+  {{- end }}
+
+
+  ### create tasks for local modul dependencies
+  {{- if $modul.local}}
   ## create dir if not exists
   - id: verify-modul-{{ $modul.modul }}
     options:
@@ -121,10 +172,16 @@ task:
           onerror: true
         action:
           script:
-            - echo "update go.work for module {{ $modul.modul }}"
+            - echo "update go.work for local module {{ $modul.modul }}"
             - go work use module/{{ $modul.modul }}
-
+  {{- end}}
 {{- end }}
+
+#### generate visual studio code workspace file
+  - id: code-workspace
+    script:
+       - "#@export-to-json vscode-ws VS_WS_CONFIG"
+       - "#@var-to-file VS_WS_CONFIG contxt.code-workspace"
 
 #### update depandabot
   - id: depandabot
@@ -135,10 +192,11 @@ task:
   - id: cleanup-dependencies
     script:
     {{- range $k, $test := $.module }}
+    {{- if $test.local}}
       - |
        cd {{ $test.modul }}
        go mod tidy
-
+    {{- end }}
     {{- end }}
       - git status
 
@@ -148,8 +206,10 @@ task:
   - id: test
     script:
     {{- range $k, $test := $.module }}
+    {{- if $test.local}}
       - echo "testing modul {{ $test.modul }}"
       - go test  -failfast ./module/{{ $test.modul }}/./...
+    {{- end }}
     {{- end }}
 
 ##### like the regular test but now we update the coverage report
@@ -168,6 +228,7 @@ task:
     script:
       - "#@set coverage-report <b></b>"
       {{- range $k, $test := $.module }}
+      {{- if $test.local}}
       - go test -cover ./module/{{ $test.modul }}/./... -coverprofile ./docs/test/coverage/test.{{ $test.modul }}.out
       - go tool cover -html ./docs/test/coverage/test.{{ $test.modul }}.out -o ./docs/test/coverage/{{ $test.modul }}.html
       - "#@add coverage-report <h2>{{ $test.modul }}</h2>"
@@ -176,6 +237,7 @@ task:
       - "#@add coverage-report ${report-cover}"
       - "#@add coverage-report </div>"
       - "#@add coverage-report <a target=\"coverage_details\" href=\"test/coverage/{{ $test.modul }}.html\">report for {{ $test.modul }}</a>"
+    {{- end }}
     {{- end }}
       - "#@var-to-file coverage ./docs/coverage.html"
 
@@ -193,15 +255,19 @@ task:
   - id: test-each
     needs:
     {{- range $k, $test := $.module }}
+    {{- if $test.local}}
       - atest-{{ $test.modul }}
+    {{- end }}
     {{- end }}
 
     {{- range $k, $test := $.module }}
+    {{- if $test.local}}
   - id: atest-{{ $test.modul }}
     options:
       displaycmd: true
     script:
       - go test -failfast -timeout {{ $test.test.timeout }} ./module/{{ $test.modul }}/./...
+    {{- end }}
     {{- end }}
 
   - id: set-version

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist/
 docs/coverage.html
 docs/test/coverage/*
 
+#auto generated files
+contxt.code-workspace
+

--- a/.moduls.yml
+++ b/.moduls.yml
@@ -1,35 +1,47 @@
 module:
   -
     modul: configure
+    local: true
     test:
       timeout: 30s
 
   -
     modul: dirhandle
+    local: true
     test:
       timeout: 30s
 
   -
     modul: systools
+    local: true
     test:
       timeout: 30s
 
   -
     modul: trigger
+    local: true
     test:
       timeout: 30s
 
   -
     modul: taskrun
+    local: true
     test:
       timeout: 60s
 
   -
     modul: awaitgroup
+    local: true
     test:
       timeout: 30s
 
   -
     modul: shellcmd
+    local: true
     test:
       timeout: 30s
+
+  -
+    modul: manout
+    local: false
+    path: ${WS0_manout_root}

--- a/imports/dependabot.tpl
+++ b/imports/dependabot.tpl
@@ -5,6 +5,7 @@
 version: 2
 updates:
 {{- range $k, $deb := $.module }}
+{{- if $deb.local }}
 ### dependencie for /module/{{ $deb.modul }}/
   - package-ecosystem: gomod
     directory: /module/{{ $deb.modul }}/
@@ -12,4 +13,5 @@ updates:
        interval: daily
     assignees:
        - swaros
+{{- end }}
 {{- end }}

--- a/imports/vscode.workspace.yml
+++ b/imports/vscode.workspace.yml
@@ -1,0 +1,9 @@
+folders:
+  - path: "."
+{{- range $k, $modul := $.module }}
+{{- if not $modul.local }}
+  - path: "{{$modul.path}}"
+{{- end }}
+{{- end }}
+
+settings: {}

--- a/module/taskrun/vardata.go
+++ b/module/taskrun/vardata.go
@@ -156,6 +156,16 @@ func GetDataAsYaml(key string) (bool, string) {
 	return false, ""
 }
 
+// GetDataAsYaml converts the map given by key infto a yaml string
+func GetDataAsJson(key string) (bool, string) {
+	if found, data := GetData(key); found {
+		if outData, err := json.MarshalIndent(data, "", "  "); err == nil {
+			return true, string(outData)
+		}
+	}
+	return false, ""
+}
+
 // ClearAllData removes all entries
 func ClearAllData() {
 	dataStorage.Range(func(key, _ interface{}) bool {

--- a/module/taskrun/varimport.go
+++ b/module/taskrun/varimport.go
@@ -61,6 +61,7 @@ const (
 	setvarMark      = "#@set"
 	setvarInMap     = "#@set-in-map"
 	exportToYaml    = "#@export-to-yaml"
+	exportToJson    = "#@export-to-json"
 	addvarMark      = "#@add"
 	equalsMark      = "#@if-equals"
 	notEqualsMark   = "#@if-not-equals"
@@ -222,6 +223,18 @@ func TryParse(script []string, regularScript func(string) (bool, int)) (bool, in
 					ExportVarToFile(varName, fileName)
 				} else {
 					manout.Error("invalid usage", writeVarToFile, " needs 2 arguments at least. <variable> <filename>")
+				}
+			case exportToJson:
+				if len(parts) == 3 {
+					mapKey := parts[1]
+					varName := parts[2]
+					if exists, newStr := GetDataAsJson(mapKey); exists {
+						SetPH(varName, HandlePlaceHolder(newStr))
+					} else {
+						manout.Error("map with key ", mapKey, " not exists")
+					}
+				} else {
+					manout.Error("invalid usage", exportToJson, " needs 2 arguments at least. <map-key> <variable>")
 				}
 			case exportToYaml:
 				if len(parts) == 3 {

--- a/version.yml
+++ b/version.yml
@@ -3,12 +3,12 @@ release:
   version:
      main: 0
      mid: 5
-     minor: 0
+     minor: 1
 # used version for the build. defines the version check in contxt.yml (ei henne problem)
 # this is the version that is needed to build the release. must be lower then the release
 # (at least once til you run a 'make install-local')
 build:
   version:
      main: 0
-     mid: 4
+     mid: 5
      minor: 0


### PR DESCRIPTION
this branch is about how to work with modules they hosted not in the repository. (as usual)

so we added a new flag for local modules in the modules.yml
and fitted the logic in contxt.yml too.

also we create a vs-code workspace file (git ignored) that will include any external repo we have in the modules file
for creating them, we added also the **export-to-json** cheat, so we can create the workspace file out of an yaml file 

