### PR TITLE
Add Support for variables argument

### DIFF
--- a/module/runner/functions.go
+++ b/module/runner/functions.go
@@ -697,3 +697,12 @@ func (c *CmdExecutorImpl) PrintTemplate() {
 		}
 	}
 }
+
+// Set the given variable to the current session Default Variables.
+// this will end up by using them as variables for the template, and are reset for any run.
+// this is also an different Behavior to V1 where the variables are set for the wohle runtime, and if
+// they changed by a task, they are changed for the whole runtime.
+// this is not happen anymore, and the variables are just set for the current run.
+func (c *CmdExecutorImpl) SetPreValue(name string, value string) {
+	c.session.DefaultVariables[name] = value
+}

--- a/module/runner/interface.go
+++ b/module/runner/interface.go
@@ -50,4 +50,5 @@ type CmdExecutor interface {
 	Lint(bool) error                                   // lint the current workspace
 	PrintShared()                                      // print out all shared libs
 	PrintTemplate()                                    // print out the current template as yaml
+	SetPreValue(name string, value string)             // set a pre value
 }

--- a/module/runner/testdata/projects01/prevalues/.contxt.yml
+++ b/module/runner/testdata/projects01/prevalues/.contxt.yml
@@ -1,0 +1,16 @@
+config:
+  variables:
+     username: "master"
+     password: "check12345"
+
+task:
+  - id: values
+    script:
+      - echo "props [${username}] [${password}]"
+  
+  - id: rewrite
+    variables:
+      username: "jon-doe"
+      password: "mysecret"
+    script:
+      - echo "reused [${username}] [${password}]"


### PR DESCRIPTION
the behavior is not the same as in V1. 
because the implementation is done by using the session Default Variables, these variables also re-applied for any new run session.
this means, if an task redefines the value for the current run, it is no longer affecting the next run, even this is done in the same session.
IMHO i like this behavior more then them from V1, because it is more reliable.

also this is now an global flag and can be used with any command. 

 