### PR TITLE
get cobra completion for shell

### DIFF
--- a/module/ctxshell/cshell.go
+++ b/module/ctxshell/cshell.go
@@ -22,7 +22,7 @@
 
 // AINC-NOTE-0815
 
- package ctxshell
+package ctxshell
 
 import (
 	"log"
@@ -58,16 +58,19 @@ func NewCshell() *Cshell {
 	}
 }
 
+// defines commands that are never executed in a separate goroutine
 func (t *Cshell) SetNeverAsyncCmds(cmds []string) *Cshell {
 	t.neverAsncCmds = cmds
 	return t
 }
 
+// defines a command that are never executed in a separate goroutine
 func (t *Cshell) SetNeverAsyncCmd(cmd ...string) *Cshell {
 	t.neverAsncCmds = append(t.neverAsncCmds, cmd...)
 	return t
 }
 
+// checks if a command is never executed in a separate goroutine
 func (t *Cshell) isNeverAsyncCmd(cmd string) bool {
 	for _, c := range t.neverAsncCmds {
 		if c == cmd {
@@ -77,16 +80,19 @@ func (t *Cshell) isNeverAsyncCmd(cmd string) bool {
 	return false
 }
 
+// defines commands that are ignored by the cobra command tree
 func (t *Cshell) SetIgnoreCobraCmds(cmds []string) *Cshell {
 	t.ignoreCobraCmds = cmds
 	return t
 }
 
+// defines commands they are ignored by the cobra command tree
 func (t *Cshell) SetIgnoreCobraCmd(cmd ...string) *Cshell {
 	t.ignoreCobraCmds = append(t.ignoreCobraCmds, cmd...)
 	return t
 }
 
+// checks if a command is ignored by the cobra command tree
 func (t *Cshell) isIgnoreCobraCmd(cmd string) bool {
 	for _, c := range t.ignoreCobraCmds {
 		if c == cmd {
@@ -96,46 +102,66 @@ func (t *Cshell) isIgnoreCobraCmd(cmd string) bool {
 	return false
 }
 
+// this sets the duration of the tick timer for print the buffered messages
+// this is required because the readline instance is not thread safe.
+// so we have to collect any output from any threads and print it in the main thread synchronously
 func (t *Cshell) SetTickTimerDuration(d time.Duration) *Cshell {
 	t.tickTimerDuration = d
 	return t
 }
 
+// this resizes the message buffer
 func (t *Cshell) ResizeMessageProvider(size int) *Cshell {
 	t.messages = NewCshellMsgScope(size)
 	return t
 }
 
+// set the cobra root command. this is the root of the cobra command tree
+// it is used to parse the command line and execute the commands, and
+// to get the flags and arguments for the completer
 func (t *Cshell) SetCobraRootCommand(cmd *cobra.Command) *Cshell {
 	t.CobraRootCmd = cmd
 	return t
 }
 
+// add a native command to the shell. native commands are just a wrapper
 func (t *Cshell) AddNativeCmd(cmd *NativeCmd) *Cshell {
 	t.navtiveCmds = append(t.navtiveCmds, cmd)
 	return t
 }
 
+// set the prompt function. this function is called every time the prompt
+// is printed. so you can change the prompt string dynamically
 func (t *Cshell) SetPromptFunc(f func() string) *Cshell {
 	t.getPrompt = f
 	return t
 }
 
+// set the exit command string. this is the command string that exits the shell
 func (t *Cshell) SetExitCmdStr(s string) *Cshell {
 	t.exitCmdStr = s
 	return t
 }
 
+// enable or disable the async execution of cobra commands
 func (t *Cshell) SetAsyncCobraExec(b bool) *Cshell {
 	t.asyncCobraExec = b
 	return t
 }
 
+// enable or disable the async execution of native commands
 func (t *Cshell) SetAsyncNativeCmd(b bool) *Cshell {
 	t.asyncNativeCmd = b
 	return t
 }
 
+// we initialize the completer with the native commands and the cobra command tree
+// the native commands are just a wrapper for the completion
+// together with the exec function
+// the cobra command tree is parsed and the commands are added to the completer
+// the flags are added to the completer too
+// the completer function of the cobra command is called only once and the result
+// is added to the completer
 func (t *Cshell) createCompleter() *readline.PrefixCompleter {
 	completer := readline.NewPrefixCompleter()
 	for _, c := range t.navtiveCmds {
@@ -147,15 +173,22 @@ func (t *Cshell) createCompleter() *readline.PrefixCompleter {
 
 	}
 
+	// parsing the cobra command tree
+	// start with the root command
 	if t.CobraRootCmd != nil {
+		// get all commands from the root command and iterate over them
 		for _, c := range t.CobraRootCmd.Commands() {
+			// ignore commands that are in the ignore list
 			if t.isIgnoreCobraCmd(c.Name()) {
 				continue
 			}
+			// create a new completer item
 			newCmd := readline.PcItem(c.Name())
+			// if the command has subcommands, we have to create a completer for them
 			if c.HasSubCommands() {
 				newCmd = t.createSubCommandCompleter(newCmd, c)
 			}
+			// add the flags from the cobra command to the completer
 			c.Flags().VisitAll(func(f *pflag.Flag) {
 				if f.Shorthand != "" {
 					newCmd.Children = append(newCmd.Children, readline.PcItem("-"+f.Shorthand))
@@ -164,7 +197,7 @@ func (t *Cshell) createCompleter() *readline.PrefixCompleter {
 					newCmd.Children = append(newCmd.Children, readline.PcItem("--"+f.Name))
 				}
 			})
-
+			t.ApplyCobraCompletionOnce(newCmd, c)
 			completer.Children = append(completer.Children, newCmd)
 		}
 	}
@@ -172,6 +205,7 @@ func (t *Cshell) createCompleter() *readline.PrefixCompleter {
 	return completer
 }
 
+// createSubCommandCompleter creates a completer for the subcommands of the cobra command
 func (t *Cshell) createSubCommandCompleter(compl *readline.PrefixCompleter, cmd *cobra.Command) *readline.PrefixCompleter {
 	for _, c := range cmd.Commands() {
 		newCmd := readline.PcItem(c.Name())
@@ -186,9 +220,34 @@ func (t *Cshell) createSubCommandCompleter(compl *readline.PrefixCompleter, cmd 
 				newCmd.Children = append(newCmd.Children, readline.PcItem("--"+f.Name))
 			}
 		})
+		// check if the command has a completer function
+		t.ApplyCobraCompletionOnce(newCmd, c)
 		compl.Children = append(compl.Children, newCmd)
 	}
 	return compl
+}
+
+// ApplyCobraCompletionOnce applies the completer function of the cobra command
+// only once. this is necessary because the completer function is called
+// every time the user hits the tab key. so just read the valid args once
+// and add them to the completer item.
+// that means, if somehow the valid args are changing, the user have to restart
+// the shell.
+func (t *Cshell) ApplyCobraCompletionOnce(newCmd *readline.PrefixCompleter, c *cobra.Command) {
+	if c.ValidArgsFunction != nil {
+		// if yes, we have to add the completer function to the completer item.
+		// we execute the completer function with an empty slice of strings
+		// and get a slice of strings back. we add them to the completer item
+		sliceRes, _ := c.ValidArgsFunction(t.CobraRootCmd, []string{}, "")
+
+		for _, s := range sliceRes {
+			// replace tab with space
+			s = strings.ReplaceAll(s, "\t", " ")
+			// we want only the first word of the result
+			s = strings.Split(s, " ")[0]
+			newCmd.Children = append(newCmd.Children, readline.PcItem(s))
+		}
+	}
 }
 
 // cmd have to be taken from the first word of the comand line.
@@ -235,6 +294,7 @@ func (t *Cshell) RunOnceWithCmd(cmd func()) error {
 
 // Run starts the shell
 func (t *Cshell) Run() error {
+	// create the completer
 	completer := t.createCompleter()
 	var err error
 	t.rlInstance, err = readline.NewEx(&readline.Config{


### PR DESCRIPTION
parses now the outcome from cobra completion callback, and adds them to the readline completion.
this is done once startup. 
will see if an more dynamic behavior is required later.

also did these changes
 - more comments as i need some time to figure out, what i had in mind. so next time i should now better.
 - remove usage of template reloading to display current project. replaced them by the path. this fixes issues while async task producing errors because of raise conditions.  
 - removes dir from async blacklist
 - add exit as native comand.