### PR TITLE
160 improve task watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ contxt.code-workspace
 #any directory callec xxx_local.only_xxx
 *_local.only_*
 
+# temporary
+*.tmp
+*.temp

--- a/module/ctxshell/cshell.go
+++ b/module/ctxshell/cshell.go
@@ -56,6 +56,7 @@ type Cshell struct {
 	updatePromptDuration time.Duration      // the period for updating the prompt
 	updatePromptEnabled  bool               // if true, the prompt is updated periodically
 	lastInput            string             // the last input
+	StopOutput           bool               // stop printing the output to stdout
 
 }
 
@@ -67,6 +68,12 @@ func NewCshell() *Cshell {
 		updatePromptDuration: 5 * time.Second,
 		neverAsncCmds:        []string{},
 	}
+}
+
+// enable or disable the output to stdout
+func (t *Cshell) SetStopOutput(b bool) *Cshell {
+	t.StopOutput = b
+	return t
 }
 
 // defines commands that are never executed in a separate goroutine

--- a/module/ctxshell/ctxoutimp.go
+++ b/module/ctxshell/ctxoutimp.go
@@ -66,8 +66,10 @@ func (t *Cshell) StartMessageProvider() error {
 			select {
 			case <-time.After(time.Duration(t.tickTimerDuration)):
 				msgs := t.messages.GetAllMessages()
-				for _, msg := range msgs {
-					t.rlInstance.Stdout().Write([]byte(msg.Msg))
+				if !t.StopOutput {
+					for _, msg := range msgs {
+						t.rlInstance.Stdout().Write([]byte(msg.Msg))
+					}
 				}
 			case <-done:
 				break loop

--- a/module/ctxshell/messageprovider.go
+++ b/module/ctxshell/messageprovider.go
@@ -22,7 +22,7 @@
 
 // AINC-NOTE-0815
 
- package ctxshell
+package ctxshell
 
 import "time"
 

--- a/module/runner/ctxshell.go
+++ b/module/runner/ctxshell.go
@@ -22,6 +22,7 @@
 package runner
 
 import (
+	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -70,6 +71,9 @@ func shellRunner(c *CmdExecutorImpl) {
 	// afterwards we can add the commands by injecting the root command
 	shell.SetCobraRootCommand(c.session.Cobra.RootCmd)
 
+	// rename the exit command to quit
+	shell.SetExitCmdStr("quit")
+
 	// some of the commands are not working well async, because they
 	// are switching between workspaces. so we have to disable async
 	// for them
@@ -77,15 +81,16 @@ func shellRunner(c *CmdExecutorImpl) {
 
 	// add native exit command
 	exitCmd := ctxshell.NewNativeCmd("exit", "exit the shell", func(args []string) error {
-		ctxout.PrintLn(ctxout.ForeBlue, "bye bye", ctxout.CleanTag)
 		systools.Exit(0)
 		return nil
 	})
+	// completer function for the exit command
 	exitCmd.SetCompleterFunc(func(line string) []string {
 		return []string{"exit"}
 	})
 	shell.AddNativeCmd(exitCmd)
 
+	// add task clean command
 	cleanTasksCmd := ctxshell.NewNativeCmd("taskreset", "resets all tasks", func(args []string) error {
 		return tasks.NewGlobalWatchman().ResetAllTasksIfPossible()
 	})
@@ -94,8 +99,32 @@ func shellRunner(c *CmdExecutorImpl) {
 	})
 	shell.AddNativeCmd(cleanTasksCmd)
 
+	// add task stop command
 	stoppAllCmd := ctxshell.NewNativeCmd("stoptasks", "stop all the running processes", func(args []string) error {
-		tasks.NewGlobalWatchman().StopAllTasks(nil)
+		ctxshell.NewCshell().SetStopOutput(true)
+		tasks.NewGlobalWatchman().StopAllTasks(func(target string, time int, succeed bool) {
+			if succeed {
+				ctxout.PrintLn(ctxout.NewMOWrap(), "stopped process: ", target)
+			} else {
+				ctxout.PrintLn(ctxout.NewMOWrap(), "failed to stop processes: ", target)
+			}
+		})
+		ctxshell.NewCshell().SetStopOutput(false)
+		tasks.HandleAllMyPid(func(pid int) error {
+			ctxout.PrintLn(ctxout.NewMOWrap(), "killing process: ", pid)
+			if proc, err := os.FindProcess(pid); err == nil {
+				if err := proc.Kill(); err != nil {
+					return err
+				} else {
+					ctxout.PrintLn(ctxout.NewMOWrap(), "killed process: ", pid)
+				}
+			} else {
+				ctxout.PrintLn(ctxout.NewMOWrap(), "failed to kill process: ", pid)
+				return err
+			}
+			return nil
+		})
+
 		return nil
 	})
 	stoppAllCmd.SetCompleterFunc(func(line string) []string {

--- a/module/runner/ctxshell.go
+++ b/module/runner/ctxshell.go
@@ -94,6 +94,15 @@ func shellRunner(c *CmdExecutorImpl) {
 	})
 	shell.AddNativeCmd(cleanTasksCmd)
 
+	stoppAllCmd := ctxshell.NewNativeCmd("stoptasks", "stop all the running processes", func(args []string) error {
+		tasks.NewGlobalWatchman().StopAllTasks(nil)
+		return nil
+	})
+	stoppAllCmd.SetCompleterFunc(func(line string) []string {
+		return []string{"stoptasks"}
+	})
+	shell.AddNativeCmd(stoppAllCmd)
+
 	// set the prompt handler
 	shell.SetPromptFunc(func(reason int) string {
 

--- a/module/systools/errorcodes.go
+++ b/module/systools/errorcodes.go
@@ -22,7 +22,7 @@
 
 // AINC-NOTE-0815
 
- package systools
+package systools
 
 const (
 	ExitOk               = 0   // Everything is fine

--- a/module/systools/exitctl.go
+++ b/module/systools/exitctl.go
@@ -22,9 +22,12 @@
 
 // AINC-NOTE-0815
 
- package systools
+package systools
 
-import "os"
+import (
+	"os"
+	"os/signal"
+)
 
 type ExitBehavior struct {
 	proceedWithExit bool
@@ -56,4 +59,24 @@ func Exit(code int) bool {
 	}
 	os.Exit(code)
 	return true
+}
+
+// WatchSigTerm adds a callback function
+// that will be executed if the app receives
+// a SIGTERM signal
+// if no callback is given, the app will exit
+// with code 0 and all registered callbacks will
+// be executed
+func WatchSigTerm(callback func(os.Signal)) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		for sig := range c {
+			if callback != nil {
+				callback(sig)
+			} else {
+				Exit(0)
+			}
+		}
+	}() // exit
 }

--- a/module/systools/sanitize.go
+++ b/module/systools/sanitize.go
@@ -22,7 +22,7 @@
 
 // AINC-NOTE-0815
 
- package systools
+package systools
 
 import "strings"
 

--- a/module/systools/shell.go
+++ b/module/systools/shell.go
@@ -22,7 +22,7 @@
 
 // AINC-NOTE-0815
 
- package systools
+package systools
 
 // Just maps the term functions and use StdOut as default
 import (

--- a/module/systools/stringHlp.go
+++ b/module/systools/stringHlp.go
@@ -79,6 +79,20 @@ func PrintableChars(str string) string {
 	return string(result)
 }
 
+// returns the string where any spaces, with an length of more than 1
+// are replaced by one space
+// so "hello   my friend" will be "hello my friend"
+func TrimAllSpaces(s string) string {
+	sp := strings.Split(s, " ")
+	newSl := []string{}
+	for _, v := range sp {
+		if v != "" {
+			newSl = append(newSl, v)
+		}
+	}
+	return strings.Join(newSl, " ")
+}
+
 func NoEscapeSequences(str string) string {
 	// we need to remove any escape sequences from the string
 	// for output without colors and countingchars they are visible

--- a/module/systools/stringHlp_test.go
+++ b/module/systools/stringHlp_test.go
@@ -156,3 +156,10 @@ func TestPathStringSub(t *testing.T) {
 	}
 
 }
+
+func TestStringTrimAllSpaces(t *testing.T) {
+	str := systools.TrimAllSpaces("hello   my friend")
+	if str != "hello my friend" {
+		t.Error("string should be reduced: ", str)
+	}
+}

--- a/module/tasks/asserts_test.go
+++ b/module/tasks/asserts_test.go
@@ -91,6 +91,13 @@ func assertIntEqual(t *testing.T, expected int, actual int) {
 	}
 }
 
+func assertIntGreater(t *testing.T, expected int, actual int) {
+	t.Helper()
+	if expected >= actual {
+		t.Errorf("expected [%d] to be greater than [%d]", expected, actual)
+	}
+}
+
 func assertNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/module/tasks/asserts_test.go
+++ b/module/tasks/asserts_test.go
@@ -84,6 +84,20 @@ func assertStrEqual(t *testing.T, expected string, actual string) {
 	}
 }
 
+func assertIntEqual(t *testing.T, expected int, actual int) {
+	t.Helper()
+	if expected != actual {
+		t.Errorf("expected [%d], but got [%d]", expected, actual)
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("expected no error, but got %v", err)
+	}
+}
+
 func assertPositionInSliceBefore(t *testing.T, slice []string, substr string, before string) {
 	t.Helper()
 	substrIndex := -1

--- a/module/tasks/cmdDefines.go
+++ b/module/tasks/cmdDefines.go
@@ -153,3 +153,11 @@ func (s *shellRunner) ExecSilentAndReturnLast(command string) (string, int) {
 	}, func(p *os.Process) {})
 	return last, code
 }
+
+func (s *shellRunner) GetCmd() string {
+	return s.cmd
+}
+
+func (s *shellRunner) GetArgs() []string {
+	return s.args
+}

--- a/module/tasks/execTemplate.go
+++ b/module/tasks/execTemplate.go
@@ -337,7 +337,7 @@ func (t *targetExecuter) executeTemplate(runAsync bool, target string, scopeVars
 			// preparing codelines by execute second level commands
 			// that can affect the whole script
 			abort, returnCode, _ = t.TryParse(script.Script, func(codeLine string) (bool, int) {
-				lineAbort, lineExitCode := t.lineExecuter(codeLine, script)
+				lineAbort, lineExitCode := t.targetTaskExecuter(codeLine, script, t.watch)
 				return lineExitCode, lineAbort
 			})
 			if abort {

--- a/module/tasks/header.go
+++ b/module/tasks/header.go
@@ -135,6 +135,7 @@ func (t *targetExecuter) reInitialize() {
 	// if no task watcher is set, we create a new one
 	if t.watch == nil {
 		t.watch = NewGlobalWatchman()
+		t.watch.SetLogger(t.getLogger())
 	}
 	// assign the Tasks to the targetExecuter
 
@@ -158,6 +159,9 @@ func (t *targetExecuter) CopyToTarget(target string) *targetExecuter {
 
 func (t *targetExecuter) SetLogger(logger mimiclog.Logger) *targetExecuter {
 	t.Logger = logger
+	if t.watch != nil {
+		t.watch.SetLogger(logger)
+	}
 	return t
 }
 

--- a/module/tasks/lineExec.go
+++ b/module/tasks/lineExec.go
@@ -34,10 +34,10 @@ import (
 	"github.com/swaros/contxt/module/systools"
 )
 
-// lineExecuter is the main function to execute a script line
+// targetTaskExecuter is the main function to execute a script line
 // it returns the exit code of the executed command
 // and a boolean value if the execution was successful
-func (t *targetExecuter) lineExecuter(codeLine string, currentTask configure.Task) (int, bool) {
+func (t *targetExecuter) targetTaskExecuter(codeLine string, currentTask configure.Task, watchman *Watchman) (int, bool) {
 	replacedLine := codeLine
 	if t.phHandler != nil {
 		replacedLine = t.phHandler.HandlePlaceHolderWithScope(codeLine, t.arguments) // placeholders
@@ -93,6 +93,16 @@ func (t *targetExecuter) lineExecuter(codeLine string, currentTask configure.Tas
 			pidStr := fmt.Sprintf("%d", process.Pid) // we use them as info for the user only
 			t.setPh("RUN.PID", pidStr)
 			t.setPh("RUN."+t.target+".PID", pidStr)
+			// update watchman with the process infos, if there is an task for this target
+			// this should be the case always by any watchman target update, but we check it anyway
+			if wtask, found := watchman.GetTask(t.target); found {
+				wtask.StartTrackProcess(process)
+				wtask.LogCmd(runCmd, runArgs, replacedLine)
+				if err := watchman.UpdateTask(t.target, wtask); err != nil {
+					t.getLogger().Error("can not update task", err)
+					t.out(MsgError(MsgError{Err: err, Reference: codeLine, Target: currentTask.ID}))
+				}
+			}
 			if currentTask.Options.Displaycmd {
 				t.out(MsgPid(process.Pid), MsgProcess("started"))
 			}
@@ -216,7 +226,7 @@ func (t *targetExecuter) listenerWatch(logLine string, e error, currentTask *con
 						t.getLogger().Debug("TRIGGER SCRIPT ACTION", triggerScript)
 						subRun := t.CopyToTarget(t.target)
 						subRun.SetArgs(dummyArgs)
-						subRun.lineExecuter(triggerScript, *currentTask)
+						subRun.targetTaskExecuter(triggerScript, *currentTask, t.watch)
 					}
 
 				}

--- a/module/tasks/lineExec.go
+++ b/module/tasks/lineExec.go
@@ -193,7 +193,11 @@ func Execute(dCmd string, dCmdArgs []string, command string, callback func(strin
 		m := scanner.Text()
 		keepRunning := callback(m, nil)
 		if !keepRunning {
-			cmd.Process.Kill()
+			if runtime.GOOS == "linux" {
+				syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			} else {
+				cmd.Process.Kill()
+			}
 			return systools.ExitByStopReason, 0, err
 		}
 

--- a/module/tasks/procs.go
+++ b/module/tasks/procs.go
@@ -1,0 +1,59 @@
+package tasks
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+func FindChildPid(pid int) ([]int, error) {
+	var procList []int
+	// only linux is supported
+	// but others should not fail
+	if runtime.GOOS != "linux" {
+		return procList, nil
+	}
+	command := fmt.Sprintf("ps -o pid --no-headers --ppid %d", pid)
+	runner := GetShellRunner()
+	// internalExitCode, processExitCode, err
+	intCode, realCode, err := runner.Exec(
+		command,
+		func(msg string, err error) bool {
+			if err == nil {
+				var code int
+				fmt.Sscanf(msg, "%d", &code)
+				procList = append(procList, code)
+			}
+			return true
+		},
+		func(proc *os.Process) {
+
+		},
+	)
+	if err != nil {
+		return procList, err
+	}
+	if intCode != 0 {
+		return procList, fmt.Errorf("command %s failed with internal exit code %d", command, intCode)
+	}
+	if realCode != 0 {
+		return procList, fmt.Errorf("command %s failed with exit code %d", command, realCode)
+	}
+	return procList, nil
+}
+
+func HandleAllMyPid(handlePid func(pid int) error) error {
+	//mainProcs, err := FindChildPid(os.Getppid())
+	procs, err := FindChildPid(os.Getpid())
+	if err != nil {
+		return err
+	}
+
+	for _, pid := range procs {
+		if err := handlePid(pid); err != nil {
+			return err
+		}
+	}
+	return nil
+
+}

--- a/module/tasks/procs_test.go
+++ b/module/tasks/procs_test.go
@@ -1,0 +1,19 @@
+package tasks_test
+
+import (
+	"testing"
+
+	"github.com/swaros/contxt/module/tasks"
+)
+
+func TestTask(t *testing.T) {
+	pids := []int{}
+	tasks.HandleAllMyPid(func(pid int) error {
+		pids = append(pids, pid)
+		return nil
+	})
+
+	if len(pids) == 0 {
+		t.Error("no pids found")
+	}
+}

--- a/module/tasks/watchman.go
+++ b/module/tasks/watchman.go
@@ -70,11 +70,11 @@ func ListWatcherInstances() []string {
 	return inst
 }
 
-func ShutDownProcesses() {
+func ShutDownProcesses(reportFn func(target string, time int, succeed bool)) {
 	instanceMutex.Lock()
 	defer instanceMutex.Unlock()
 	for _, wm := range instances {
-		wm.StopAllTasks(nil)
+		wm.StopAllTasks(reportFn)
 	}
 }
 

--- a/module/tasks/watchmanTask.go
+++ b/module/tasks/watchmanTask.go
@@ -1,0 +1,80 @@
+package tasks
+
+import (
+	"os"
+	"syscall"
+)
+
+// TaskDef holds information about running
+// and finished tasks
+type TaskDef struct {
+	uuid       string
+	started    bool
+	count      int
+	done       bool
+	doneCount  int
+	process    *ProcessDef
+	processLog []ProcessLog
+}
+
+type ProcessDef struct {
+	handlingDone bool // task wise done. did not mean it is not running anymore
+	processInfo  *os.Process
+}
+
+type ProcessLog struct {
+	Cmd     string
+	Args    []string
+	Command string
+	Pid     int
+}
+
+func (ts *TaskDef) StartTrackProcess(proc *os.Process) {
+	ts.process = &ProcessDef{
+		handlingDone: false,
+		processInfo:  proc,
+	}
+}
+
+func (ts *TaskDef) StopTrackProcess() {
+	ts.process = nil
+}
+
+func (ts *TaskDef) GetProcess() *ProcessDef {
+	return ts.process
+}
+
+func (ts *TaskDef) LogCmd(cmd string, args []string, command string) {
+	pid := 0
+	if ts.process != nil && ts.process.processInfo != nil {
+		pid = ts.process.processInfo.Pid
+	}
+	ts.processLog = append(ts.processLog, ProcessLog{
+		Cmd:     cmd,
+		Args:    args,
+		Pid:     pid,
+		Command: command,
+	})
+}
+
+func (ts *TaskDef) IsProcessRunning() bool {
+	if ts.process == nil {
+		return false
+	}
+	if ts.process.processInfo != nil {
+		if ts.process.processInfo.Pid > 0 {
+			proc, err := os.FindProcess(ts.process.processInfo.Pid)
+			if err == nil {
+				if err := proc.Signal(syscall.Signal(0)); err != nil {
+					return false
+				}
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (ts *TaskDef) GetProcessLog() []ProcessLog {
+	return ts.processLog
+}

--- a/module/tasks/watchmanTask.go
+++ b/module/tasks/watchmanTask.go
@@ -27,6 +27,7 @@ package tasks
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"syscall"
 )
 
@@ -107,6 +108,9 @@ func (ts *TaskDef) GetProcessLog() []ProcessLog {
 func (ts *TaskDef) KillProcess() error {
 	if ts.process != nil && ts.process.processInfo != nil {
 		if ts.IsProcessRunning() {
+			if runtime.GOOS == "linux" {
+				return syscall.Kill(-ts.process.processInfo.Pid, syscall.SIGKILL)
+			}
 			return ts.process.processInfo.Kill()
 		} else {
 			return fmt.Errorf("process %d is not running", ts.process.processInfo.Pid)

--- a/module/tasks/watchmanTask.go
+++ b/module/tasks/watchmanTask.go
@@ -127,18 +127,9 @@ func (ts *TaskDef) StopProcessIfRunning() error {
 		if ts.IsProcessRunning() {
 			return ts.process.processInfo.Signal(os.Interrupt)
 		}
+	} else {
+		fmt.Println("no process to stop")
 	}
-	return nil
-}
 
-func (ts *TaskDef) WaitProcess() error {
-	if ts.process != nil && ts.process.processInfo != nil {
-		if ts.IsProcessRunning() {
-			_, err := ts.process.processInfo.Wait()
-			return err
-		} else {
-			return fmt.Errorf("process %d is not running", ts.process.processInfo.Pid)
-		}
-	}
-	return fmt.Errorf("no process to wait for")
+	return nil
 }

--- a/module/tasks/watchman_test.go
+++ b/module/tasks/watchman_test.go
@@ -2,9 +2,13 @@ package tasks_test
 
 import (
 	"os"
+	"runtime"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/swaros/contxt/module/systools"
 	"github.com/swaros/contxt/module/tasks"
 )
 
@@ -129,6 +133,282 @@ func TestWatchManTaskInfo(t *testing.T) {
 		}
 	} else {
 		t.Errorf("expected task to be found, but it is not")
+	}
+
+}
+
+func helperForFindTask(t *testing.T, cmdlike string) []string {
+	t.Helper()
+	// we use linux special features here
+	if runtime.GOOS != "linux" {
+		t.Skip("not supported on anything else than linux")
+	}
+	runner := tasks.GetShellRunner()
+	command := "ps -ef"
+	result := []string{}
+	runner.Exec(
+		command,
+		func(msg string, err error) bool {
+			if strings.Contains(msg, cmdlike) {
+				result = append(result, msg)
+			}
+			return true
+		},
+		func(proc *os.Process) {
+		},
+	)
+	return result
+}
+
+func helperKillTask(t *testing.T, pid string) []string {
+	t.Helper()
+	// we use linux special features here
+	if runtime.GOOS != "linux" {
+		t.Skip("not supported on anything else than linux")
+	}
+	runner := tasks.GetShellRunner()
+	command := "kill -9 " + pid
+	result := []string{"command [" + command + "]"}
+	runner.Exec(
+		command,
+		func(msg string, err error) bool {
+			result = append(result, msg)
+			return true
+		},
+		func(proc *os.Process) {
+		},
+	)
+	return result
+}
+
+func helperLaunchShellCmdInBackround(t *testing.T, command, target string, wman *tasks.Watchman, forceStop bool) {
+	t.Helper()
+	runner := tasks.GetShellRunner()
+	// make sure we create a new task
+	wman.IncTaskCount(target)
+
+	go runner.Exec(
+		command,
+		func(msg string, err error) bool {
+			if forceStop {
+				return false
+			}
+			return err == nil
+		},
+		func(proc *os.Process) {
+			if wtask, found := wman.GetTask(target); found {
+				wtask.StartTrackProcess(proc)
+				wtask.LogCmd(runner.GetCmd(), runner.GetArgs(), command)
+				if err := wman.UpdateTask(target, wtask); err != nil {
+					t.Errorf("expected no error, but got %v", err)
+				}
+
+				// testing if the task is still running
+				// this is done by checking the processInfo of the task.
+				// it depends on the os, if the processInfo is still valid
+				if !wtask.IsProcessRunning() {
+					t.Error("expected process to be running, but it is not")
+				}
+			}
+		},
+	)
+}
+
+// testing the process tracking by an background task, and stop it
+// by sending a SIGTERM and SIGKILL to the process.
+// here we do ot use the watchman to stop the task
+// we use the os directly, so none of watchman kill methods are used.
+// this is done to test the process tracking
+// kill methods of the watchman are tested in TestTaskStoppingByWatchman
+func TestTaskTracking(t *testing.T) {
+	// we use linux special features here
+	if runtime.GOOS != "linux" {
+		t.Skip("not supported on anything else than linux")
+	}
+
+	// start a task in the background and let it run for 1 second
+	// and try to stop it
+	// this is done by sending a SIGTERM to the process
+	// and then checking if the process is still running
+	// if it is still running, we send a SIGKILL to the process
+	// and check again if the process is still running
+	// if it is still running, we fail the test
+
+	// this is the command we want to run
+	command := "sleep 1"
+	// this is the target we want to use
+	target := "taskKillSleeper"
+	// this is the watchman we want to use
+	wman := tasks.NewWatchman()
+	// we use the helper to launch the command in the background
+	helperLaunchShellCmdInBackround(t, command, target, wman, false)
+
+	// wait till the process is started
+	if success, timeUsed := wman.WaitForProcessStart(target, 10*time.Millisecond, 10); !success {
+		t.Error("failed to start process in time", timeUsed)
+	}
+	// get the task
+	if wtask, found := wman.GetTask(target); found {
+		if !wtask.IsProcessRunning() {
+			t.Error("expected process to be running, but it is not")
+		}
+		// get the process
+		proc := wtask.GetProcess()
+		if proc == nil {
+			t.Error("expected process not to be nil")
+		}
+		// get the processInfo
+		// get the pid
+		pid, _ := wtask.GetProcessPid()
+		if pid == 0 {
+			t.Error("expected pid not to be 0")
+		}
+		// send the SIGTERM
+		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+			t.Errorf("expected no error, but got %v", err)
+		}
+		// wait a bit, so the process can stop
+		time.Sleep(100 * time.Millisecond)
+		// check if the process is still running
+		if wtask.IsProcessRunning() {
+			// send the SIGKILL
+			if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+				t.Errorf("expected no error, but got %v", err)
+			}
+			// wait a bit, so the process can stop
+			time.Sleep(100 * time.Millisecond)
+			// check if the process is still running
+			if wtask.IsProcessRunning() {
+				t.Error("expected process not to be running, but it is")
+			}
+		}
+	} else {
+		t.Errorf("expected task to be found, but it is not")
+	}
+
+}
+
+func TestTaskStoppingByWatchman(t *testing.T) {
+	// we use linux special features here
+	if runtime.GOOS != "linux" {
+		t.Skip("not supported on anything else than linux")
+	}
+	// see TestTaskTracking for more details about the propsed workflow
+	command := "sleep 10"
+	target := "watchmanKillTask"
+	wman := tasks.NewWatchman()
+	helperLaunchShellCmdInBackround(t, command, target, wman, false)
+
+	if success, timeUsed := wman.WaitForProcessStart(target, 10*time.Millisecond, 10); !success {
+		t.Error("failed to start process in time", timeUsed)
+	}
+	if wtask, found := wman.GetTask(target); found {
+		err := wtask.KillProcess()
+		if err != nil {
+			t.Errorf("expected no error, but got [%v]", err)
+		}
+		time.Sleep(100 * time.Millisecond)
+		if wtask.IsProcessRunning() {
+			t.Error("expected process not to be running, but it is")
+		}
+	} else {
+		t.Errorf("expected task to be found, but it is not")
+	}
+
+}
+
+// testing if we run in the timeout, because the task is not started
+// so we expect the WaitForProcessStart to run into the timeout
+func TestWMWaitForProceesStart(t *testing.T) {
+	wman := tasks.NewWatchman()
+	target := "neverStatedTask"
+	if success, timeUsed := wman.WaitForProcessStart(target, 10*time.Millisecond, 10); !success {
+		assertIntEqual(t, 100000000, timeUsed)
+	} else {
+		t.Error("expected to fail, but it did not")
+	}
+}
+
+func TestMultipleTaskManagement(t *testing.T) {
+	command := "sleep 5"
+
+	wman := tasks.NewWatchman()
+
+	targets := map[string]string{
+		"multiTask1": command,
+		"multiTask2": command,
+		"multiTask3": command,
+	}
+
+	for target, command := range targets {
+		helperLaunchShellCmdInBackround(t, command, target, wman, false)
+	}
+
+	for target := range targets {
+		if success, timeUsed := wman.WaitForProcessStart(target, 5*time.Millisecond, 10); !success {
+			t.Error("failed to start process in time", timeUsed)
+		}
+	}
+	tasks.ShutDownProcesses()
+	for target := range targets {
+		_, found := wman.GetTask(target)
+		if !found {
+			t.Errorf("expected task %q to be found, but it is not", target)
+		}
+
+	}
+
+}
+
+func TestMultipleTaskManagementWithChildProcs(t *testing.T) {
+	command := "sleep 5"
+
+	wman := tasks.NewWatchman()
+
+	targets := map[string]string{
+		"multiTask1": command,
+		"multiTask2": "watch date > dateout.bin.tmp",
+		"multiTask3": command,
+	}
+
+	for target, command := range targets {
+		helperLaunchShellCmdInBackround(t, command, target, wman, false)
+	}
+
+	for target := range targets {
+		if success, timeUsed := wman.WaitForProcessStart(target, 5*time.Millisecond, 10); !success {
+			t.Error("failed to start process in time", timeUsed)
+		}
+	}
+	wman.StopAllTasks(func(target string, time int, succeed bool) {
+		t.Log("task", target, "stopped in", time, "ms")
+		if !succeed {
+			t.Error("task", target, "did not succeed by stopping his process")
+		}
+	})
+	for target := range targets {
+		_, found := wman.GetTask(target)
+		if !found {
+			t.Errorf("expected task %q to be found, but it is not", target)
+		}
+
+	}
+	tasks := helperForFindTask(t, "watch date")
+	for _, task := range tasks {
+
+		t.Error("expected 'watch date' to be stopped, but it is not:\n", task)
+		task = systools.TrimAllSpaces(task)
+		t.Log(task)
+		parts := strings.Split(task, " ")
+		if len(parts) > 1 {
+			pid := parts[1]
+			t.Log("killing task", pid)
+			killInfo := helperKillTask(t, pid)
+			for _, killMsg := range killInfo {
+				t.Log(killMsg)
+			}
+		}
+
 	}
 
 }

--- a/module/tasks/watchman_test.go
+++ b/module/tasks/watchman_test.go
@@ -1,6 +1,7 @@
 package tasks_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -47,6 +48,87 @@ func TestWatchmanDoneCheck(t *testing.T) {
 
 	if !wm.GetTaskDone("task2") {
 		t.Errorf("expected task2 to be done, but it is not")
+	}
+
+}
+
+// testing the basic workflow of tracking a process
+func TestWatchManTaskInfo(t *testing.T) {
+	runner := tasks.GetShellRunner()
+	command := "echo 'hello watchman'"
+
+	target := "task1"
+	wman := tasks.NewWatchman()
+	wman.IncTaskCount(target)
+	trackPid := 0
+
+	// internalExitCode, processExitCode, err
+	intCode, realCode, err := runner.Exec(
+		command,
+		func(msg string, err error) bool {
+			if err != nil {
+				t.Errorf("expected no error, but got %v", err)
+			}
+			t.Log("output:", msg)
+			return true
+		},
+		func(proc *os.Process) {
+			trackPid = proc.Pid
+			if wtask, found := wman.GetTask(target); found {
+				wtask.StartTrackProcess(proc)
+				wtask.LogCmd(runner.GetCmd(), runner.GetArgs(), command)
+				if err := wman.UpdateTask(target, wtask); err != nil {
+					t.Errorf("expected no error, but got %v", err)
+					// if this is not working, anything else will also fail for sure.
+					// no need to spam the test with more errors
+					t.SkipNow()
+				}
+
+				// testing if the task is still running
+				// this is done by checking the processInfo of the task.
+				// it depends on the os, if the processInfo is still valid
+				if !wtask.IsProcessRunning() {
+					t.Error("expected process to be running, but it is not")
+				}
+			}
+		},
+	)
+	assertNoError(t, err)
+	assertIntEqual(t, 0, intCode)
+	assertIntEqual(t, 0, realCode)
+
+	if wtask, found := wman.GetTask(target); found {
+		checkTheTask := wtask.GetProcess()
+		if checkTheTask == nil {
+			t.Errorf("expected task to have process, but it does not")
+		}
+
+		if wtask.IsProcessRunning() {
+			t.Errorf("expected is no longer running, but it is")
+		}
+		if wtask.GetProcess() == nil {
+			t.Errorf("expected process not to be nil")
+		}
+		if len(wtask.GetProcessLog()) != 1 {
+			t.Errorf("expected processLog to have 1 entry, but it has %d", len(wtask.GetProcessLog()))
+		} else {
+			// doing this in else, because we need the first entry
+			firstLog := wtask.GetProcessLog()[0]
+			if firstLog.Cmd != runner.GetCmd() {
+				t.Errorf("expected processLog to have cmd %q, but it has %q", runner.GetCmd(), firstLog.Cmd)
+			}
+			if len(firstLog.Args) != len(runner.GetArgs()) {
+				t.Errorf("expected processLog to have args %q, but it has %q", runner.GetArgs(), firstLog.Args)
+			}
+			if firstLog.Command != command {
+				t.Errorf("expected processLog to have command %q, but it has %q", command, firstLog.Command)
+			}
+			if firstLog.Pid != trackPid {
+				t.Errorf("expected processLog to have pid %d, but it has %d", trackPid, firstLog.Pid)
+			}
+		}
+	} else {
+		t.Errorf("expected task to be found, but it is not")
 	}
 
 }


### PR DESCRIPTION
added different approaches to handle the running tasks.
there are some different behaviors, depending created child processes, where it is hard, to figure out to stop them all, independent from how they are created.

so the first attempt is just to track all created processes in watchman, and if needed go through all of them and stop them.
this works as long no child processes are spawned. 
to stop the easiest variant like "bash -c watch date > date.tmp" i solved it by this
[stackoverflow](https://stackoverflow.com/questions/34095254/panic-in-other-goroutine-not-stopping-child-process/34095869#34095869) for linux os.

but this is not working for more complex environments, like running java in a shell.
this is solved by the "final" attempt, on linux only, to get all child processes from contxt itself and stop them.
this is done by just calling the linux command ps with the own PID and hill any found child

in addition the CTRL+ C is now captured, and so all the cleanup tasks forced to be run in this case.